### PR TITLE
Use `repl-prompt` parameter value for nrepl prompt

### DIFF
--- a/nrepl.scm
+++ b/nrepl.scm
@@ -11,7 +11,7 @@
 (define (nrepl-loop in-port out-port)
 
   (define (print-repl-prompt op)
-    (display "#;> " op)
+    (display ((repl-prompt)) op)
     (flush-output op))
 
   ;; stolen from Chicken Core's eval.scm


### PR DESCRIPTION
Allows the user to set a given repl's prompt in the standard way.

``` scheme
(parameterize ((repl-prompt (constantly "lolcats> ")))
  (nrepl 8888))
```
